### PR TITLE
Filter unreceived purchase order items

### DIFF
--- a/app/Http/Controllers/PurchaseEntryController.php
+++ b/app/Http/Controllers/PurchaseEntryController.php
@@ -69,14 +69,106 @@ class PurchaseEntryController extends Controller
         // Fetch parties that have at least one purchase order
         $parties = Party::whereHas('purchaseOrders')->orderBy('name')->get();
 
-        // Fetch only pending/approved purchase orders
-        $purchaseOrders = PurchaseOrder::whereIn('status', ['pending', 'partial'])->orderBy('purchase_order_number', 'desc')->get();
+        // Fetch only purchase orders with remaining items (pending/partial status)
+        // We'll load these via AJAX for better performance and search functionality
+        $purchaseOrders = collect(); // Empty collection, will be loaded via AJAX
 
         // Pass all products for the dynamic "Add Product" functionality
         $products = Product::orderBy('name')->get();
 
         return view('purchase_entries.create', compact('parties', 'products', 'purchaseOrders'));
     }
+
+    /**
+     * Get purchase orders with remaining items for purchase entry creation
+     */
+    public function getPurchaseOrdersWithRemainingItems(Request $request)
+    {
+        $search = $request->get('search', '');
+        
+        $query = PurchaseOrder::with(['party', 'items.product', 'receiptNoteItems', 'purchaseEntryItems']);
+
+        // Apply search filter if provided
+        if (!empty($search)) {
+            $query->where(function($q) use ($search) {
+                $q->where('purchase_order_number', 'LIKE', '%' . $search . '%')
+                  ->orWhereHas('party', function($partyQuery) use ($search) {
+                      $partyQuery->where('name', 'LIKE', '%' . $search . '%');
+                  });
+            });
+        }
+
+        $purchaseOrders = $query->orderBy('purchase_order_number', 'desc')->get();
+
+        // Filter purchase orders that have remaining items
+        $filteredPOs = $purchaseOrders->filter(function($po) {
+            // Calculate received quantities from both sources
+            $receivedViaNote = $po->receiptNoteItems
+                ->where('status', 'received')
+                ->groupBy('product_id')
+                ->map(fn($items) => $items->sum('quantity'));
+            
+            $receivedViaEntry = $po->purchaseEntryItems
+                ->where('status', 'received')
+                ->groupBy('product_id')
+                ->map(fn($items) => $items->sum('quantity'));
+
+            // Check if any item has remaining quantity
+            foreach ($po->items as $item) {
+                $fromNote = $receivedViaNote->get($item->product_id, 0);
+                $fromEntry = $receivedViaEntry->get($item->product_id, 0);
+                $totalReceived = $fromNote + $fromEntry;
+                $remaining = $item->quantity - $totalReceived;
+
+                if ($remaining > 0) {
+                    return true; // This PO has at least one item with remaining quantity
+                }
+            }
+
+            return false; // All items are fully received
+        });
+
+        // Format data for Select2
+        $formattedData = $filteredPOs->map(function($po) {
+            // Calculate total remaining items for display
+            $receivedViaNote = $po->receiptNoteItems
+                ->where('status', 'received')
+                ->groupBy('product_id')
+                ->map(fn($items) => $items->sum('quantity'));
+            
+            $receivedViaEntry = $po->purchaseEntryItems
+                ->where('status', 'received')
+                ->groupBy('product_id')
+                ->map(fn($items) => $items->sum('quantity'));
+
+            $remainingCount = 0;
+            foreach ($po->items as $item) {
+                $fromNote = $receivedViaNote->get($item->product_id, 0);
+                $fromEntry = $receivedViaEntry->get($item->product_id, 0);
+                $totalReceived = $fromNote + $fromEntry;
+                $remaining = $item->quantity - $totalReceived;
+                if ($remaining > 0) {
+                    $remainingCount++;
+                }
+            }
+
+            return [
+                'id' => $po->id,
+                'text' => $po->purchase_order_number . ' - ' . $po->party->name . ' (' . $remainingCount . ' items pending)',
+                'purchase_order_number' => $po->purchase_order_number,
+                'party_name' => $po->party->name,
+                'party_id' => $po->party_id,
+                'remaining_count' => $remainingCount,
+                'status' => $po->receipt_status
+            ];
+        })->values();
+
+        return response()->json([
+            'results' => $formattedData,
+            'pagination' => ['more' => false]
+        ]);
+    }
+
     public function store(Request $request)
     {
         Log::info('Starting purchase entry store method', $request->all());

--- a/app/Http/Controllers/ReceiptNoteController.php
+++ b/app/Http/Controllers/ReceiptNoteController.php
@@ -31,13 +31,104 @@ class ReceiptNoteController extends Controller
         // Fetch parties that have at least one purchase order
         $parties = Party::whereHas('purchaseOrders')->orderBy('name')->get();
 
-        // Fetch only pending/approved purchase orders
-        $purchaseOrders = PurchaseOrder::whereIn('status', ['pending', 'partial'])->orderBy('purchase_order_number', 'desc')->get();
+        // Fetch only purchase orders with remaining items (pending/partial status)
+        // We'll load these via AJAX for better performance and search functionality
+        $purchaseOrders = collect(); // Empty collection, will be loaded via AJAX
 
         // Pass all products for the dynamic "Add Product" functionality
         $products = Product::orderBy('name')->get();
 
         return view('receipt_notes.create', compact('parties', 'products', 'purchaseOrders'));
+    }
+
+    /**
+     * Get purchase orders with remaining items for receipt note creation
+     */
+    public function getPurchaseOrdersWithRemainingItems(Request $request)
+    {
+        $search = $request->get('search', '');
+        
+        $query = PurchaseOrder::with(['party', 'items.product', 'receiptNoteItems', 'purchaseEntryItems']);
+
+        // Apply search filter if provided
+        if (!empty($search)) {
+            $query->where(function($q) use ($search) {
+                $q->where('purchase_order_number', 'LIKE', '%' . $search . '%')
+                  ->orWhereHas('party', function($partyQuery) use ($search) {
+                      $partyQuery->where('name', 'LIKE', '%' . $search . '%');
+                  });
+            });
+        }
+
+        $purchaseOrders = $query->orderBy('purchase_order_number', 'desc')->get();
+
+        // Filter purchase orders that have remaining items
+        $filteredPOs = $purchaseOrders->filter(function($po) {
+            // Calculate received quantities from both sources
+            $receivedViaNote = $po->receiptNoteItems
+                ->where('status', 'received')
+                ->groupBy('product_id')
+                ->map(fn($items) => $items->sum('quantity'));
+            
+            $receivedViaEntry = $po->purchaseEntryItems
+                ->where('status', 'received')
+                ->groupBy('product_id')
+                ->map(fn($items) => $items->sum('quantity'));
+
+            // Check if any item has remaining quantity
+            foreach ($po->items as $item) {
+                $fromNote = $receivedViaNote->get($item->product_id, 0);
+                $fromEntry = $receivedViaEntry->get($item->product_id, 0);
+                $totalReceived = $fromNote + $fromEntry;
+                $remaining = $item->quantity - $totalReceived;
+
+                if ($remaining > 0) {
+                    return true; // This PO has at least one item with remaining quantity
+                }
+            }
+
+            return false; // All items are fully received
+        });
+
+        // Format data for Select2
+        $formattedData = $filteredPOs->map(function($po) {
+            // Calculate total remaining items for display
+            $receivedViaNote = $po->receiptNoteItems
+                ->where('status', 'received')
+                ->groupBy('product_id')
+                ->map(fn($items) => $items->sum('quantity'));
+            
+            $receivedViaEntry = $po->purchaseEntryItems
+                ->where('status', 'received')
+                ->groupBy('product_id')
+                ->map(fn($items) => $items->sum('quantity'));
+
+            $remainingCount = 0;
+            foreach ($po->items as $item) {
+                $fromNote = $receivedViaNote->get($item->product_id, 0);
+                $fromEntry = $receivedViaEntry->get($item->product_id, 0);
+                $totalReceived = $fromNote + $fromEntry;
+                $remaining = $item->quantity - $totalReceived;
+                if ($remaining > 0) {
+                    $remainingCount++;
+                }
+            }
+
+            return [
+                'id' => $po->id,
+                'text' => $po->purchase_order_number . ' - ' . $po->party->name . ' (' . $remainingCount . ' items pending)',
+                'purchase_order_number' => $po->purchase_order_number,
+                'party_name' => $po->party->name,
+                'party_id' => $po->party_id,
+                'remaining_count' => $remainingCount,
+                'status' => $po->receipt_status
+            ];
+        })->values();
+
+        return response()->json([
+            'results' => $formattedData,
+            'pagination' => ['more' => false]
+        ]);
     }
 
     public function store(Request $request)

--- a/resources/views/purchase_entries/create.blade.php
+++ b/resources/views/purchase_entries/create.blade.php
@@ -107,13 +107,9 @@
                                 <div class="col-md-6">
                                     <label for="purchase_order_id" class="form-label">Purchase Order</label>
                                     <select name="purchase_order_id" id="purchase_order_id" class="form-select select2" required>
-                                        <option value="" selected disabled>Select a Purchase Order...</option>
-                                        @foreach($purchaseOrders as $po)
-                                        <option value="{{ $po->id }}" {{ old('purchase_order_id') == $po->id ? 'selected' : '' }}>
-                                            {{ $po->purchase_order_number }} - {{ $po->party->name }}
-                                        </option>
-                                        @endforeach
+                                        <option value="" selected disabled>-- Type to search PO with remaining items --</option>
                                     </select>
+                                    <small class="form-text text-muted">Only showing purchase orders with remaining items to receive</small>
                                 </div>
 
                                 <div class="col-md-6">
@@ -195,6 +191,58 @@
     <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
     <script>
         $(document).ready(function() {
+            // Initialize Select2 for Purchase Order field with AJAX
+            $('#purchase_order_id').select2({
+                theme: 'bootstrap-5',
+                placeholder: 'Type to search for purchase orders...',
+                allowClear: true,
+                minimumInputLength: 0,
+                ajax: {
+                    url: '{{ route("purchase_entries.search_purchase_orders") }}',
+                    dataType: 'json',
+                    delay: 300,
+                    data: function (params) {
+                        return {
+                            search: params.term || ''
+                        };
+                    },
+                    processResults: function (data) {
+                        return {
+                            results: data.results
+                        };
+                    },
+                    cache: true
+                },
+                templateResult: function(item) {
+                    if (!item.id) {
+                        return item.text;
+                    }
+                    
+                    // Create custom template showing PO details
+                    var $result = $(
+                        '<div class="d-flex justify-content-between align-items-center">' +
+                            '<div>' +
+                                '<div class="fw-bold text-primary">' + (item.purchase_order_number || '') + '</div>' +
+                                '<div class="text-muted small">' + (item.party_name || '') + '</div>' +
+                            '</div>' +
+                            '<div class="text-end">' +
+                                '<span class="badge bg-warning text-dark">' + (item.remaining_count || 0) + ' items pending</span>' +
+                            '</div>' +
+                        '</div>'
+                    );
+                    return $result;
+                },
+                templateSelection: function(item) {
+                    if (item.purchase_order_number) {
+                        return item.purchase_order_number + ' - ' + item.party_name + ' (' + item.remaining_count + ' items pending)';
+                    }
+                    return item.text;
+                }
+            });
+
+            // Load initial data when page loads
+            $('#purchase_order_id').select2('open').select2('close');
+
             const productsList = $('#products-list');
             const productsHeader = $('.products-header');
 
@@ -203,7 +251,16 @@
                 const poId = $(this).val();
                 if (!poId) return resetForm();
 
+                // Get the selected option data from Select2
+                const selectedData = $(this).select2('data')[0];
+                
                 productsList.html('<p class="text-muted text-center p-4">Loading...</p>');
+
+                // Pre-fill party information from Select2 data if available
+                if (selectedData && selectedData.party_name) {
+                    $('#party_name').val(selectedData.party_name);
+                    $('#party_id').val(selectedData.party_id);
+                }
 
                 $.ajax({
                     url: `/purchase-orders/${poId}/details`,

--- a/resources/views/receipt_notes/create.blade.php
+++ b/resources/views/receipt_notes/create.blade.php
@@ -105,13 +105,11 @@
                             <div class="row g-3">
                                <div class="col-md-6">
                                     <label for="purchase_order_id" class="form-label">Select Purchase Order</label>
-                                    <select name="purchase_order_id" id="purchase_order_id" class="form-select" required>
-                                        <option value="" selected disabled>-- Select a PO to load items --</option>
-                                        @foreach($purchaseOrders as $po)
-                                            <option value="{{ $po->id }}">{{ $po->purchase_order_number }} - {{ $po->party->name }}</option>
-                                        @endforeach
+                                    <select name="purchase_order_id" id="purchase_order_id" class="form-select select2" required>
+                                        <option value="" selected disabled>-- Type to search PO with remaining items --</option>
                                     </select>
                                     <input type="hidden" name="purchase_order_number" id="purchase_order_number" value="{{ old('purchase_order_number') }}">
+                                    <small class="form-text text-muted">Only showing purchase orders with remaining items to receive</small>
                                     @error('purchase_order_id')
                                         <div class="text-danger">{{ $message }}</div>
                                     @enderror
@@ -200,6 +198,57 @@
     <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
     <script>
         $(document).ready(function() {
+            // Initialize Select2 for Purchase Order field with AJAX
+            $('#purchase_order_id').select2({
+                theme: 'bootstrap-5',
+                placeholder: 'Type to search for purchase orders...',
+                allowClear: true,
+                minimumInputLength: 0,
+                ajax: {
+                    url: '{{ route("receipt_notes.search_purchase_orders") }}',
+                    dataType: 'json',
+                    delay: 300,
+                    data: function (params) {
+                        return {
+                            search: params.term || ''
+                        };
+                    },
+                    processResults: function (data) {
+                        return {
+                            results: data.results
+                        };
+                    },
+                    cache: true
+                },
+                templateResult: function(item) {
+                    if (!item.id) {
+                        return item.text;
+                    }
+                    
+                    // Create custom template showing PO details
+                    var $result = $(
+                        '<div class="d-flex justify-content-between align-items-center">' +
+                            '<div>' +
+                                '<div class="fw-bold text-primary">' + (item.purchase_order_number || '') + '</div>' +
+                                '<div class="text-muted small">' + (item.party_name || '') + '</div>' +
+                            '</div>' +
+                            '<div class="text-end">' +
+                                '<span class="badge bg-warning text-dark">' + (item.remaining_count || 0) + ' items pending</span>' +
+                            '</div>' +
+                        '</div>'
+                    );
+                    return $result;
+                },
+                templateSelection: function(item) {
+                    if (item.purchase_order_number) {
+                        return item.purchase_order_number + ' - ' + item.party_name + ' (' + item.remaining_count + ' items pending)';
+                    }
+                    return item.text;
+                }
+            });
+
+            // Load initial data when page loads
+            $('#purchase_order_id').select2('open').select2('close');
             const productsList = $('#products-list');
             const productsHeader = $('.products-header');
 
@@ -208,7 +257,17 @@
                 const poId = $(this).val();
                 if (!poId) return resetForm();
 
+                // Get the selected option data from Select2
+                const selectedData = $(this).select2('data')[0];
+                
                 productsList.html('<p class="text-muted text-center p-4">Loading...</p>');
+
+                // Pre-fill party information from Select2 data if available
+                if (selectedData && selectedData.party_name) {
+                    $('#party_name').val(selectedData.party_name);
+                    $('#party_id').val(selectedData.party_id);
+                    $('#purchase_order_number').val(selectedData.purchase_order_number);
+                }
 
                 $.ajax({
                     url: `/purchase-orders/${poId}/details`,

--- a/routes/web.php
+++ b/routes/web.php
@@ -154,6 +154,7 @@ Route::middleware('auth')->group(function () {
     Route::get('/purchase-entries', [PurchaseEntryController::class, 'index'])->name('purchase_entries.index');
     Route::get('/purchase-entries/create', [PurchaseEntryController::class, 'create'])->name('purchase_entries.create');
     Route::post('/purchase-entries', [PurchaseEntryController::class, 'store'])->name('purchase_entries.store');
+    Route::get('/purchase-entries/purchase-orders/search', [PurchaseEntryController::class, 'getPurchaseOrdersWithRemainingItems'])->name('purchase_entries.search_purchase_orders');
     Route::get('/purchase-entries/{purchaseEntry}/edit', [PurchaseEntryController::class, 'edit'])->name('purchase_entries.edit');
     Route::put('/purchase-entries/{purchaseEntry}', [PurchaseEntryController::class, 'update'])->name('purchase_entries.update');
     Route::post('/purchase-entries/check-invoice', [PurchaseEntryController::class, 'checkInvoiceNumber'])->name('purchase_entries.check_invoice');
@@ -163,6 +164,7 @@ Route::middleware('auth')->group(function () {
     Route::get('/receipt_notes', [ReceiptNoteController::class, 'index'])->name('receipt_notes.index');
     Route::get('/receipt_notes/create', [ReceiptNoteController::class, 'create'])->name('receipt_notes.create');
     Route::post('/receipt_notes', [ReceiptNoteController::class, 'store'])->name('receipt_notes.store');
+    Route::get('/receipt_notes/purchase-orders/search', [ReceiptNoteController::class, 'getPurchaseOrdersWithRemainingItems'])->name('receipt_notes.search_purchase_orders');
     // THE FIX: Add these two routes for the conversion workflow
     Route::get('/receipt-notes/{id}/convert', [ReceiptNoteController::class, 'convert'])->name('receipt_notes.convert');
     Route::post('/receipt-notes/{id}/store-conversion', [ReceiptNoteController::class, 'storeConversion'])->name('receipt_notes.store_conversion');


### PR DESCRIPTION
Filter Purchase Order selection to show only pending items and add search on receipt/purchase entry forms.

The previous implementation displayed all purchase orders, including fully received ones, which could lead to user errors and a cluttered selection list. This change ensures users can only select relevant purchase orders and quickly find them using the new search functionality.

---

**Open Background Agent:** 
[Web](https://www.cursor.com/agents?id=bc-684c9b1b-60ec-4d84-a6a1-3a75933ca3af) · [Cursor](https://cursor.com/background-agent?bcId=bc-684c9b1b-60ec-4d84-a6a1-3a75933ca3af)

Learn more about [Background Agents](https://docs.cursor.com/background-agent/web-and-mobile)